### PR TITLE
show failure in changes on bad rename and fix label on failures

### DIFF
--- a/frontend/src/pages/store/EditorStore.ts
+++ b/frontend/src/pages/store/EditorStore.ts
@@ -880,6 +880,10 @@ export const editorStore: StateCreator<EditorStore, [], [], EditorStoreBase> = (
       new: newId,
     });
     await get().applyConstraints();
+    const failures = get().failures;
+    if (failures.length === 0) {
+        get().selectResource(newId);
+    }
   },
   navigateRightSidebar: (selector: RightSidebarTabSelector) => {
     const sidebarState = get().editorSidebarState;

--- a/frontend/src/shared/reactflow/ResourceGroupNode.tsx
+++ b/frontend/src/shared/reactflow/ResourceGroupNode.tsx
@@ -174,13 +174,6 @@ const ResourceGroupNode = memo(
                   data.resourceId,
                   new NodeId(type, namespace, newValue, provider),
                 );
-                if (
-                  selectedResource?.toString() === data.resourceId.toString()
-                ) {
-                  selectResource(
-                    new NodeId(type, namespace, newValue, provider),
-                  );
-                }
               }}
               initialValue={data.resourceId.name}
             />
@@ -281,6 +274,8 @@ const EditableLabel: FC<EditableLabelProps> = ({
               e.preventDefault();
               if (state.label !== label) {
                 onSubmit?.(state.label);
+                // reset the label in case of failure, if success it will get reset anyways
+                state.label = label
               }
               setIsEditing(false);
             }}

--- a/frontend/src/shared/reactflow/ResourceNode.tsx
+++ b/frontend/src/shared/reactflow/ResourceNode.tsx
@@ -216,9 +216,6 @@ const ResourceNode = memo(({ id, data, isConnectable }: ResourceNodeProps) => {
               data.resourceId,
               new NodeId(type, namespace, newValue, provider),
             );
-            if (selectedResource?.toString() === data.resourceId.toString()) {
-              selectResource(new NodeId(type, namespace, newValue, provider));
-            }
           }}
         ></EditableLabel>
         <div className={"text-center dark:text-gray-200"}>
@@ -342,6 +339,8 @@ const EditableLabel: FC<EditableLabelProps> = ({
               e.preventDefault();
               if (state.label !== label) {
                 onSubmit?.(state.label);
+                // reset the label in case of failure, if success it will get reset anyways
+                state.label = label;
               }
               setIsEditing(false);
             }}


### PR DESCRIPTION
propagates the failure for rename into the changes tab and ensures it shows if failure.

we also didnt update the labels value when failures happened so it would reload the bad name
<img width="1350" alt="Screen Shot 2024-01-19 at 2 07 13 PM" src="https://github.com/klothoplatform/infracopilot/assets/111291520/9c30f4d2-6ef6-470a-831b-c0417dc94751">
