### PR TITLE
Use json logging for engine/iac commands

### DIFF
--- a/src/engine_service/engine_commands/util.py
+++ b/src/engine_service/engine_commands/util.py
@@ -47,6 +47,8 @@ async def run_command(
 
     cmd = [
         f"{b.path}",
+        # since we're using the engine in the service and not as a CLI, we want to log in JSON format
+        "--json-log",
         *args,
     ]
     if ENGINE_PROFILING and cwd is not None:


### PR DESCRIPTION
A small change, but should improve readability on cloudwatch.

I believe it was intentional that these are in JSON form based on the EngineException function:
```py
    def err_log_str(self):
        err_logs = [
            json.loads(line)
            for line in self.stderr.splitlines()
            if line.startswith("{")
        ]
        return "\n".join(
            f'{entry["level"].upper()}: {entry["msg"]}'
            for entry in err_logs
            if (
                entry["level"] in ["warn", "error"]
                and "Not logged in" not in entry["msg"]
                and "Klotho compilation failed" not in entry["msg"]
            )
        )
```