### PR TITLE
fix ability to set primitive lists

### DIFF
--- a/frontend/src/components/editor/ConfigForm.tsx
+++ b/frontend/src/components/editor/ConfigForm.tsx
@@ -205,7 +205,6 @@ export default function ConfigForm({
           const resourceMetadata =
             environmentVersion.resources.get(resourceIdStr);
 
-          console.log(non_empty_values, "non_empty_values");
           const constraintMetadata = generateConstraintMetadataFromFormState(
             resourceMetadata,
             non_empty_values,

--- a/frontend/src/components/editor/ConfigForm.tsx
+++ b/frontend/src/components/editor/ConfigForm.tsx
@@ -205,6 +205,7 @@ export default function ConfigForm({
           const resourceMetadata =
             environmentVersion.resources.get(resourceIdStr);
 
+          console.log(non_empty_values, "non_empty_values");
           const constraintMetadata = generateConstraintMetadataFromFormState(
             resourceMetadata,
             non_empty_values,

--- a/frontend/src/shared/architecture/Constraints.spec.ts
+++ b/frontend/src/shared/architecture/Constraints.spec.ts
@@ -221,6 +221,74 @@ describe("generateConstraintMetadataFromFormState", () => {
     });
   });
 
+  it("should set the last list value for nested lists", () => {
+    const mockResourceType: ResourceType = {
+      provider: "testProvider",
+      type: "testType",
+      displayName: "testDisplayName",
+      views: new Map(),
+      properties: [
+        {
+          name: "testProperty",
+          qualifiedName: "testProperty",
+          type: CollectionTypes.Map,
+          properties: [
+            {
+              name: "nestedProperty",
+              qualifiedName: "nestedProperty",
+              type: CollectionTypes.List,
+              itemType: CollectionTypes.List,
+              properties: [
+                {
+                  name: "nestedList",
+                  qualifiedName: "nestedList",
+                  type: CollectionTypes.List,
+                  itemType: PrimitiveTypes.String,
+                } as ListProperty,
+              ],
+            } as ListProperty,
+          ],
+        },
+      ],
+    };
+
+    const mockState = {
+      "testKey#testProperty.nestedProperty[0].nestedList[0]": {
+        value: "testValue1",
+      },
+      "testKey#testProperty.nestedProperty[1].nestedList[1]": {
+        value: "testValue2",
+      },
+    };
+
+    const mockResourceMetadata = {
+      testProperty: {
+        nestedProperty: [
+          {
+            nestedList: [],
+          },
+          {
+            nestedList: ["testOldValue1", "testOldValue2"],
+          },
+        ],
+      },
+    };
+
+    const result = generateConstraintMetadataFromFormState(
+      mockResourceMetadata,
+      mockState,
+      mockResourceType,
+    );
+
+    expect(result).toEqual({
+      "testProperty.nestedProperty[0].nestedList": ["testValue1"],
+      "testProperty.nestedProperty[1].nestedList": [
+        "testOldValue1",
+        "testValue2",
+      ],
+    });
+  });
+
   it("should ignore synthetic properties", () => {
     const mockResourceType: ResourceType = {
       provider: "testProvider",

--- a/frontend/src/shared/architecture/Constraints.spec.ts
+++ b/frontend/src/shared/architecture/Constraints.spec.ts
@@ -1,4 +1,5 @@
-import type { ResourceType } from "../resources/ResourceTypes";
+import type { ListProperty, ResourceType } from "../resources/ResourceTypes";
+import { PrimitiveTypes } from "../resources/ResourceTypes";
 import { CollectionTypes } from "../resources/ResourceTypes";
 import {
   generateConstraintMetadataFromFormState,
@@ -136,6 +137,87 @@ describe("generateConstraintMetadataFromFormState", () => {
       testProperty: {
         testKey: "testValue",
       },
+    });
+  });
+
+  it("should set the entire list value for root primitive lists", () => {
+    const mockResourceType: ResourceType = {
+      provider: "testProvider",
+      type: "testType",
+      displayName: "testDisplayName",
+      views: new Map(),
+      properties: [
+        {
+          name: "testProperty",
+          qualifiedName: "testProperty",
+          type: CollectionTypes.List,
+          itemType: PrimitiveTypes.String,
+        } as ListProperty,
+      ],
+    };
+
+    const mockState = {
+      "testKey#testProperty[0]": { value: "testValue1" },
+      "testKey#testProperty[1]": { value: "testValue2" },
+    };
+
+    const mockResourceMetadata = {
+      testProperty: ["testOldValue1", "testOldValue2"],
+    };
+
+    const result = generateConstraintMetadataFromFormState(
+      mockResourceMetadata,
+      mockState,
+      mockResourceType,
+    );
+
+    expect(result).toEqual({
+      testProperty: ["testValue1", "testValue2"],
+    });
+  });
+
+  it("should set the entire list value for nested primitive lists", () => {
+    const mockResourceType: ResourceType = {
+      provider: "testProvider",
+      type: "testType",
+      displayName: "testDisplayName",
+      views: new Map(),
+      properties: [
+        {
+          name: "testProperty",
+          qualifiedName: "testProperty",
+          type: CollectionTypes.Map,
+          properties: [
+            {
+              name: "nestedProperty",
+              qualifiedName: "nestedProperty",
+              type: CollectionTypes.List,
+              itemType: PrimitiveTypes.String,
+            } as ListProperty,
+          ],
+        },
+      ],
+    };
+
+    const mockState = {
+      "testKey#testProperty.nestedProperty[0]": { value: "testValue1" },
+      "testKey#testProperty.nestedProperty[1]": { value: "testValue2" },
+    };
+
+    const mockResourceMetadata = {
+      testProperty: {
+        nestedProperty: ["testOldValue1", "testOldValue2"],
+      },
+    };
+
+    const result = generateConstraintMetadataFromFormState(
+      mockResourceMetadata,
+      mockState,
+      mockResourceType,
+    );
+
+    expect(result).toEqual({
+      "testProperty.nestedProperty": ["testValue1", "testValue2"],
     });
   });
 });

--- a/frontend/src/shared/architecture/Constraints.spec.ts
+++ b/frontend/src/shared/architecture/Constraints.spec.ts
@@ -220,6 +220,54 @@ describe("generateConstraintMetadataFromFormState", () => {
       "testProperty.nestedProperty": ["testValue1", "testValue2"],
     });
   });
+
+  it("should ignore synthetic properties", () => {
+    const mockResourceType: ResourceType = {
+      provider: "testProvider",
+      type: "testType",
+      displayName: "testDisplayName",
+      views: new Map(),
+      properties: [
+        {
+          name: "testProperty",
+          qualifiedName: "testProperty",
+          type: CollectionTypes.Map,
+          synthetic: true,
+          properties: [
+            {
+              name: "nestedProperty",
+              qualifiedName: "nestedProperty",
+              synthetic: true,
+              type: CollectionTypes.List,
+              itemType: CollectionTypes.Map,
+              properties: [
+                {
+                  name: "Key",
+                  qualifiedName: "Key",
+                  type: PrimitiveTypes.String,
+                },
+              ],
+            } as ListProperty,
+          ],
+        },
+      ],
+    };
+
+    const mockState = {
+      "testKey#testProperty.nestedProperty[0].Key": "testValue1",
+      "testKey#testProperty.nestedProperty[1].Key": "testValue2",
+    };
+
+    const mockResourceMetadata = {};
+
+    const result = generateConstraintMetadataFromFormState(
+      mockResourceMetadata,
+      mockState,
+      mockResourceType,
+    );
+
+    expect(result).toEqual({});
+  });
 });
 
 describe("setNestedValue", () => {

--- a/frontend/src/shared/architecture/Constraints.ts
+++ b/frontend/src/shared/architecture/Constraints.ts
@@ -348,7 +348,7 @@ export function generateConstraintMetadataFromFormState(
               field.type === CollectionTypes.Set
             ) {
               if (!currentProperty.synthetic) {
-                const val = resourceMetadata[name];
+                const val = getDataFromPath(prop, resourceMetadata);
                 if (val) {
                   path.push(prop);
                   return;
@@ -450,7 +450,11 @@ export function generateConstraintMetadataFromFormState(
           case CollectionTypes.Set:
           case CollectionTypes.List: {
             if (!val) {
-              const nonIndexPath = path.join(".").split("[")[0];
+              const nonIndexPath = path
+                .join(".")
+                .split("[")
+                .slice(0, -1)
+                .join("[");
               const currVal = getDataFromPath(nonIndexPath, resourceMetadata);
               if (currVal && constraintMetadata[nonIndexPath] === undefined) {
                 constraintMetadata[nonIndexPath] = currVal;

--- a/frontend/src/shared/architecture/Constraints.ts
+++ b/frontend/src/shared/architecture/Constraints.ts
@@ -511,12 +511,10 @@ export function generateConstraintMetadataFromFormState(
 }
 
 const getDataFromPath = (path: string, resourceMetadata: any) => {
-  console.log(path);
   const properties: string[] = path.split(".");
   // deep copy so that resource metadata doesnt get modified in parent functions
   let currentData = JSON.parse(JSON.stringify(resourceMetadata));
   properties.forEach((prop) => {
-    console.log(currentData, prop);
     const splitProp = prop.split("[");
     currentData = currentData[splitProp[0]];
     if (currentData === undefined) {

--- a/frontend/src/shared/architecture/Constraints.ts
+++ b/frontend/src/shared/architecture/Constraints.ts
@@ -332,7 +332,7 @@ export function generateConstraintMetadataFromFormState(
     let path: string[] = [];
 
     let stopPathExecution = false;
-    propertyPath.forEach((prop) => {
+    propertyPath.forEach((prop, index) => {
       const name = prop.split("[")[0];
       if (stopPathExecution) {
         return;
@@ -347,10 +347,12 @@ export function generateConstraintMetadataFromFormState(
               field.type === CollectionTypes.List ||
               field.type === CollectionTypes.Set
             ) {
-              const val = resourceMetadata[name];
-              if (val) {
-                path.push(prop);
-                return;
+              if (!currentProperty.synthetic) {
+                const val = resourceMetadata[name];
+                if (val) {
+                  path.push(prop);
+                  return;
+                }
               }
             }
             path.push(prop.split("[")[0]);
@@ -364,13 +366,15 @@ export function generateConstraintMetadataFromFormState(
               field.type === CollectionTypes.List ||
               field.type === CollectionTypes.Set
             ) {
-              const val = getDataFromPath(
-                [...path, name].join("."),
-                resourceMetadata,
-              );
-              if (val) {
-                path.push(prop);
-                return;
+              if (!currentProperty.synthetic) {
+                const val = getDataFromPath(
+                  [...path, name].join("."),
+                  resourceMetadata,
+                );
+                if (val) {
+                  path.push(prop);
+                  return;
+                }
               }
             }
             path.push(prop.split("[")[0]);
@@ -381,7 +385,7 @@ export function generateConstraintMetadataFromFormState(
       // if there is a synthetic property found we just set the constraint metadata to the value
       // this is for the case of customized configuration
       if (currentProperty.synthetic) {
-        constraintMetadata[path.join(".")] = value;
+        stopPathExecution = true;
         return;
       }
 
@@ -483,7 +487,6 @@ export function generateConstraintMetadataFromFormState(
           ? parseInt(path.slice(path.lastIndexOf("[") + 1, -1))
           : -1;
 
-        console.log(parentKey, valueKey, arrayKey, arrayIndex, isArrayIndex);
         let parentValue;
         // if it is an array we are going to splice the value out of the array
         if (isArrayIndex) {

--- a/frontend/src/shared/resources/ResourceMappings.tsx
+++ b/frontend/src/shared/resources/ResourceMappings.tsx
@@ -250,10 +250,12 @@ export const typeMappings = new Map<
           },
           groupIcon: ElasticLoadBalancing,
           discriminator: (n: any) => n?.resource?.Type?.toLowerCase(),
+          groupEnableDragTarget: true,
           variants: new Map<String, IconMapping>([
             [
               "application",
               {
+                groupEnableDragTarget: true,
                 nodeIcon: ElasticLoadBalancingNetworkLoadBalancer,
                 groupStyle: {
                   borderColor: AWS_NETWORKING_PRIMARY_COLOR,

--- a/frontend/src/shared/resources/ResourceMappings.tsx
+++ b/frontend/src/shared/resources/ResourceMappings.tsx
@@ -250,7 +250,6 @@ export const typeMappings = new Map<
           },
           groupIcon: ElasticLoadBalancing,
           discriminator: (n: any) => n?.resource?.Type?.toLowerCase(),
-          groupEnableDragTarget: true,
           variants: new Map<String, IconMapping>([
             [
               "application",


### PR DESCRIPTION
fixes primitive lists because we cant set nested properties in lists it ensures we always set the entirety of the list.

This was occuring in the command property of container definitions for ecs